### PR TITLE
Add new custom rule to validate storage account name

### DIFF
--- a/docs/rules/azurerm_storage_account_invalid_name.md
+++ b/docs/rules/azurerm_storage_account_invalid_name.md
@@ -1,0 +1,38 @@
+# azurerm_storage_account_invalid_name
+
+Warns about values that appear to be invalid based on [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs).
+
+In this rule, the string must match the regular expression `^[a-z0-9]{3,24}$``.
+
+## Example
+
+```hcl
+resource "azurerm_storage_account" "foo" {
+  name = ... // invalid value
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: "..." does not match valid pattern ^[a-z0-9]{3,24}$ (azurerm_storage_account_invalid_name)
+
+  on template.tf line 15:
+  15:   name = ... // invalid value
+
+Reference: https://github.com/terraform-linters/tflint-ruleset-azurerm/blob/v0.4.0/docs/rules/azurerm_storage_account_invalid_name.md
+
+```
+
+## Why
+
+Requests containing invalid values will return an error when calling the API by `terraform apply`.
+
+## How to Fix
+
+Replace the warned value with a valid value.
+
+## Source
+
+https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage

--- a/rules/azurerm_storage_account_invalid_name.go
+++ b/rules/azurerm_storage_account_invalid_name.go
@@ -55,7 +55,7 @@ func (r *AzurermStorageAccountInvalidNameRule) Check(runner tflint.Runner) error
 			if !r.pattern.MatchString(val) {
 				runner.EmitIssueOnExpr(
 					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9]{3,24}$`),
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, val, `^[a-z0-9]{3,24}$`),
 					attribute.Expr,
 				)
 			}

--- a/rules/azurerm_storage_account_invalid_name.go
+++ b/rules/azurerm_storage_account_invalid_name.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"fmt"
+	"regexp"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-azurerm/project"
+)
+
+// AzurermStorageAccountInvalidNameRule checks the pattern is valid
+type AzurermStorageAccountInvalidNameRule struct {
+	resourceType  string
+	attributeName string
+	pattern       *regexp.Regexp
+}
+
+// NewAzurermStorageAccountInvalidNameRule returns new rule with default attributes
+func NewAzurermStorageAccountInvalidNameRule() *AzurermStorageAccountInvalidNameRule {
+	return &AzurermStorageAccountInvalidNameRule{
+		resourceType:  "azurerm_storage_account",
+		attributeName: "name",
+		pattern:       regexp.MustCompile(`^[a-z]{3, 24}$`),
+	}
+}
+
+// Name returns the rule name
+func (r *AzurermStorageAccountInvalidNameRule) Name() string {
+	return "azurerm_storage_account_invalid_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AzurermStorageAccountInvalidNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AzurermStorageAccountInvalidNameRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AzurermStorageAccountInvalidNameRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks the pattern is valid
+func (r *AzurermStorageAccountInvalidNameRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.pattern.MatchString(val) {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z]{3, 24}$`),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/azurerm_storage_account_invalid_name.go
+++ b/rules/azurerm_storage_account_invalid_name.go
@@ -21,7 +21,7 @@ func NewAzurermStorageAccountInvalidNameRule() *AzurermStorageAccountInvalidName
 	return &AzurermStorageAccountInvalidNameRule{
 		resourceType:  "azurerm_storage_account",
 		attributeName: "name",
-		pattern:       regexp.MustCompile(`^[a-z]{3, 24}$`),
+		pattern:       regexp.MustCompile(`^[a-z0-9]{3,24}$`),
 	}
 }
 
@@ -55,7 +55,7 @@ func (r *AzurermStorageAccountInvalidNameRule) Check(runner tflint.Runner) error
 			if !r.pattern.MatchString(val) {
 				runner.EmitIssueOnExpr(
 					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z]{3, 24}$`),
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9]{3,24}$`),
 					attribute.Expr,
 				)
 			}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"strings"
+
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint-ruleset-azurerm/rules/apispec"
 )
@@ -13,3 +15,17 @@ var Rules = append([]tflint.Rule{
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
 }, apispec.Rules...)
+
+func truncateLongMessage(str string) string {
+	limit := 80
+
+	str = strings.Replace(str, "\r\n", "\n", -1)
+	str = strings.Replace(str, "\n", "\\n", -1)
+
+	r := []rune(str)
+	if len(r) > limit {
+		return string(r[0:limit]) + "..."
+	}
+
+	return str
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -11,6 +11,7 @@ import (
 var Rules = append([]tflint.Rule{
 	NewAzurermLinuxVirtualMachineInvalidSizeRule(),
 	NewAzurermLinuxVirtualMachineScaleSetInvalidSkuRule(),
+	NewAzurermStorageAccountInvalidNameRule(),
 	NewAzurermVirtualMachineInvalidVMSizeRule(),
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -1,8 +1,6 @@
 package rules
 
 import (
-	"strings"
-
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint-ruleset-azurerm/rules/apispec"
 )
@@ -16,17 +14,3 @@ var Rules = append([]tflint.Rule{
 	NewAzurermWindowsVirtualMachineInvalidSizeRule(),
 	NewAzurermWindowsVirtualMachineScaleSetInvalidSkuRule(),
 }, apispec.Rules...)
-
-func truncateLongMessage(str string) string {
-	limit := 80
-
-	str = strings.Replace(str, "\r\n", "\n", -1)
-	str = strings.Replace(str, "\n", "\\n", -1)
-
-	r := []rune(str)
-	if len(r) > limit {
-		return string(r[0:limit]) + "..."
-	}
-
-	return str
-}


### PR DESCRIPTION
This PR adds a new custom (manually generated) rule to validate an Azure storage account name.

The Microsoft doc showing the naming rules is here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage

A storage account name must be between 3 and 24 characters, and consist of lowercase letters and numbers only.  The new rule uses the regular expression `^[a-z0-9]{3,24}$` to validate the name attribute of a terraform `azurerm_storage_account` resource.

To test, follow instructions in the docs to install and configure the plugin.  Create a terraform file containing a storage account resource, then run `tflint` against the file.  If the storage account name is invalid based on the rules above, tflint should produce an error based on the new `azurerm_storage_account_invalid_name` rule.